### PR TITLE
fix: remove reference to removed feature

### DIFF
--- a/variables-expressions-and-statements/expressions.md
+++ b/variables-expressions-and-statements/expressions.md
@@ -92,7 +92,7 @@ When more than one operator appears in an expression, the order of evaluation de
 | +, -                               | Addition and subtraction                                           |
 | >>, <<                             | Right and left bitwise shift                                       |
 | <=, <, >, >=                       | Comparison operators                                               |
-| <>, ==, !=                         | Equality operators                                                 |
+| ==, !=                             | Equality operators                                                 |
 | `is`, `is not`                     | Identity operators                                                 |
 | `in`, `not in`                     | Membership operators                                               |
 | not                                | Logical operator                                                   |


### PR DESCRIPTION
<> was removed in python 3.0